### PR TITLE
Attempting to fix missing font files. 

### DIFF
--- a/app/assets/stylesheets/_bootstrap-custom.scss
+++ b/app/assets/stylesheets/_bootstrap-custom.scss
@@ -13,7 +13,7 @@ $font-size-base: 12px;
 // Reset and dependencies
 @import "bootstrap/normalize";
 @import "bootstrap/print";
-$icon-font-path: "/assets/";
+$icon-font-path: "/assets/bootstrap/";
 @import "bootstrap/glyphicons";
 
 // Core CSS


### PR DESCRIPTION
Sets the icon font path to /assets/bootstrap.