### PR TITLE
More attempts to fix sprocket issues.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,5 +17,7 @@
  */
 
 @import "bootstrap-sprockets";
-@import "bootstrap-custom";
+@import "bootstrap";
+$font-size-base: 12px;
+//@import "bootstrap-custom";
 @import "summernote";


### PR DESCRIPTION
Sets the icon font path to /assets/bootstrap.